### PR TITLE
Feat: App Header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "square-game",
       "version": "0.0.0",
       "dependencies": {
+        "pinia": "^2.0.13",
         "vue": "^3.2.25",
         "vue-router": "^4.0.14"
       },
@@ -1396,6 +1397,56 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
+    "node_modules/pinia": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.13.tgz",
+      "integrity": "sha512-B7rSqm1xNpwcPMnqns8/gVBfbbi7lWTByzS6aPZ4JOXSJD4Y531rZHDCoYWBwLyHY/8hWnXljgiXp6rRyrofcw==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.1.4",
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/vue-demi": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
@@ -1749,7 +1800,7 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3130,6 +3181,23 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
+    "pinia": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.13.tgz",
+      "integrity": "sha512-B7rSqm1xNpwcPMnqns8/gVBfbbi7lWTByzS6aPZ4JOXSJD4Y531rZHDCoYWBwLyHY/8hWnXljgiXp6rRyrofcw==",
+      "requires": {
+        "@vue/devtools-api": "^6.1.4",
+        "vue-demi": "*"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+          "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+          "requires": {}
+        }
+      }
+    },
     "postcss": {
       "version": "8.4.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
@@ -3418,7 +3486,7 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true
+      "devOptional": true
     },
     "upath": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "vue-router": "^4.0.14"
       },
       "devDependencies": {
-        "@vicons/fa": "^0.12.0",
+        "@vicons/material": "^0.12.0",
         "@vitejs/plugin-vue": "^2.3.0",
         "naive-ui": "^2.27.0",
         "typescript": "^4.5.4",
@@ -149,10 +149,10 @@
       "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
-    "node_modules/@vicons/fa": {
+    "node_modules/@vicons/material": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@vicons/fa/-/fa-0.12.0.tgz",
-      "integrity": "sha512-g2PIeJLsTHUjt6bK63LxqC0uYQB7iu+xViJOxvp1s8b9/akpXVPVWjDTTsP980/0KYyMMe4U7F/aUo7wY+MsXA==",
+      "resolved": "https://registry.npmjs.org/@vicons/material/-/material-0.12.0.tgz",
+      "integrity": "sha512-chv1CYAl8P32P3Ycwgd5+vw/OFNc2mtkKdb1Rw4T5IJmKy6GVDsoUKV3N2l208HATn7CCQphZtuPDdsm7K2kmA==",
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -2237,10 +2237,10 @@
       "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
-    "@vicons/fa": {
+    "@vicons/material": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@vicons/fa/-/fa-0.12.0.tgz",
-      "integrity": "sha512-g2PIeJLsTHUjt6bK63LxqC0uYQB7iu+xViJOxvp1s8b9/akpXVPVWjDTTsP980/0KYyMMe4U7F/aUo7wY+MsXA==",
+      "resolved": "https://registry.npmjs.org/@vicons/material/-/material-0.12.0.tgz",
+      "integrity": "sha512-chv1CYAl8P32P3Ycwgd5+vw/OFNc2mtkKdb1Rw4T5IJmKy6GVDsoUKV3N2l208HATn7CCQphZtuPDdsm7K2kmA==",
       "dev": true
     },
     "@vitejs/plugin-vue": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "vue-router": "^4.0.14"
   },
   "devDependencies": {
-    "@vicons/fa": "^0.12.0",
+    "@vicons/material": "^0.12.0",
     "@vitejs/plugin-vue": "^2.3.0",
     "naive-ui": "^2.27.0",
     "typescript": "^4.5.4",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pinia": "^2.0.13",
     "vue": "^3.2.25",
     "vue-router": "^4.0.14"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-config-provider :theme="darkTheme">
+  <n-config-provider :theme="store.darkMode ? darkTheme : lightTheme">
     <n-layout style="height: 100vh">
       <rup-header> </rup-header>
       <rup-content> </rup-content>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,27 +1,26 @@
 <template>
   <n-config-provider :theme="darkTheme">
     <n-layout style="height: 100vh">
-      <rup-header :windowWidth="windowWidth"> </rup-header>
+      <rup-header> </rup-header>
       <rup-content> </rup-content>
     </n-layout>
   </n-config-provider>
 </template>
 
 <script setup lang="ts">
-import { defineComponent, ref } from "vue";
+import { defineComponent } from "vue";
+import { useStore } from "./store/store";
 import { darkTheme, lightTheme, NConfigProvider, NLayout } from "naive-ui";
 import { RupHeader, RupContent } from "./components";
 
-const windowWidth = ref<number>(innerWidth);
+const store = useStore();
 
-const getWindowWidth = () => {
-  windowWidth.value = innerWidth;
-};
-
-onresize = getWindowWidth;
+onresize = store.setWindowWidth;
 
 defineComponent({
   darkTheme,
   lightTheme,
+  RupHeader,
+  RupContent,
 });
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,24 @@
 <template>
   <n-config-provider :theme="darkTheme">
     <n-layout style="height: 100vh">
-      <rup-header> </rup-header>
+      <rup-header :windowWidth="windowWidth"> </rup-header>
       <rup-content> </rup-content>
     </n-layout>
   </n-config-provider>
 </template>
 
 <script setup lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, ref } from "vue";
 import { darkTheme, lightTheme, NConfigProvider, NLayout } from "naive-ui";
 import { RupHeader, RupContent } from "./components";
+
+const windowWidth = ref<number>(innerWidth);
+
+const getWindowWidth = () => {
+  windowWidth.value = innerWidth;
+};
+
+onresize = getWindowWidth;
 
 defineComponent({
   darkTheme,

--- a/src/components/RupContent.vue
+++ b/src/components/RupContent.vue
@@ -15,7 +15,7 @@ import { RupFooter } from "../components";
 
 <style scoped>
 .main-layout {
-  top: 70px;
+  top: 64px;
   padding: 0px;
 }
 </style>

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -7,9 +7,7 @@
       <n-h3 class="title">Rup Games</n-h3>
     </div>
     <div class="links">
-      <router-link to="/">Home</router-link>
-      <router-link to="/about">About</router-link>
-      <router-link to="/play">Play</router-link>
+      <n-menu mode="horizontal" :options="menuOptions" />
     </div>
     <n-icon size="30">
       <menu-sharp />
@@ -18,10 +16,47 @@
 </template>
 
 <script setup lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, h } from "vue";
 import { RouterLink } from "vue-router";
-import { NLayoutHeader, NIcon, NH3 } from "naive-ui";
+import { NLayoutHeader, NIcon, NH3, NMenu } from "naive-ui";
+import type { MenuOption } from "naive-ui";
 import { DiamondSharp, MenuSharp } from "@vicons/material";
+
+const menuOptions: MenuOption[] = [
+  {
+    label: () =>
+      h(
+        RouterLink,
+        {
+          to: "/",
+        },
+        { default: () => "Home" }
+      ),
+    key: "home",
+  },
+  {
+    label: () =>
+      h(
+        RouterLink,
+        {
+          to: "/about",
+        },
+        { default: () => "About" }
+      ),
+    key: "about",
+  },
+  {
+    label: () =>
+      h(
+        RouterLink,
+        {
+          to: "/play",
+        },
+        { default: () => "Play" }
+      ),
+    key: "play",
+  },
+];
 
 defineComponent({
   DiamondSharp,

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -9,7 +9,7 @@
     <div class="links">
       <n-menu mode="horizontal" :options="menuOptions" />
     </div>
-    <n-icon size="30">
+    <n-icon size="30" v-if="windowWidth < 600">
       <menu-sharp />
     </n-icon>
   </n-layout-header>
@@ -21,6 +21,10 @@ import { RouterLink } from "vue-router";
 import { NLayoutHeader, NIcon, NH3, NMenu } from "naive-ui";
 import type { MenuOption } from "naive-ui";
 import { DiamondSharp, MenuSharp } from "@vicons/material";
+
+defineProps<{
+  windowWidth: Number;
+}>();
 
 const menuOptions: MenuOption[] = [
   {

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -10,7 +10,11 @@
       class="links"
       v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
     >
-      <n-menu mode="horizontal" :options="menuOptions" />
+      <n-menu
+        :value="`${currentRoute.name}`"
+        mode="horizontal"
+        :options="menuOptions"
+      />
     </div>
     <n-button
       ghost
@@ -21,10 +25,10 @@
     >
       <template #icon>
         <n-icon size="20">
-          <light-mode-outlined />
+          <dark-mode-outlined />
         </n-icon>
       </template>
-      Light
+      Dark
     </n-button>
     <n-button
       ghost
@@ -35,10 +39,10 @@
     >
       <template #icon>
         <n-icon size="20">
-          <dark-mode-outlined />
+          <light-mode-outlined />
         </n-icon>
       </template>
-      Dark
+      Light
     </n-button>
     <n-icon
       size="30"
@@ -51,7 +55,7 @@
 
 <script setup lang="ts">
 import { defineComponent, h } from "vue";
-import { RouterLink } from "vue-router";
+import { RouterLink, useRoute } from "vue-router";
 import { NLayoutHeader, NIcon, NH3, NMenu, NButton } from "naive-ui";
 import type { MenuOption } from "naive-ui";
 import { useStore } from "../store/store";
@@ -63,6 +67,7 @@ import {
 } from "@vicons/material";
 
 const store = useStore();
+const currentRoute = useRoute();
 
 function disableDarkMode(isDark: boolean) {
   store.setDarkMode(isDark);
@@ -74,7 +79,9 @@ const menuOptions: MenuOption[] = [
       h(
         RouterLink,
         {
-          to: "/",
+          to: {
+            name: "home",
+          },
         },
         { default: () => "Home" }
       ),
@@ -96,7 +103,9 @@ const menuOptions: MenuOption[] = [
       h(
         RouterLink,
         {
-          to: "/play",
+          to: {
+            name: "play",
+          },
         },
         { default: () => "Play" }
       ),

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -1,55 +1,75 @@
 <template>
   <n-layout-header bordered>
-    <div class="logo-title">
+    <div class="side-container-left">
       <n-icon size="30" class="logo">
         <diamond-sharp />
       </n-icon>
       <n-h3 class="title">Rup Games</n-h3>
     </div>
+
     <div
-      class="links"
+      class="menu"
       v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
     >
       <n-menu
         :value="`${currentRoute.name}`"
         mode="horizontal"
-        :options="menuOptions"
+        :options="appNavigation"
       />
     </div>
-    <n-button
-      ghost
-      @click="disableDarkMode(true)"
-      type="primary"
-      v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
-      v-if="!store.darkMode"
-    >
-      <template #icon>
-        <n-icon size="20">
-          <dark-mode-outlined />
-        </n-icon>
-      </template>
-      Dark
-    </n-button>
-    <n-button
-      ghost
-      @click="disableDarkMode(false)"
-      type="primary"
-      v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
-      v-else
-    >
-      <template #icon>
-        <n-icon size="20">
-          <light-mode-outlined />
-        </n-icon>
-      </template>
-      Light
-    </n-button>
-    <n-icon
-      size="30"
-      v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
-    >
-      <menu-sharp />
-    </n-icon>
+
+    <div class="side-container-right">
+      <n-button
+        class="side-container-item"
+        text
+        tag="a"
+        href="https://github.com/waylonturbes/square-game"
+        target="_blank"
+        v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
+      >
+        GitHub
+      </n-button>
+
+      <n-button
+        ghost
+        style="margin-left: 20px"
+        @click="disableDarkMode(true)"
+        type="default"
+        v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
+        v-if="!store.darkMode"
+      >
+        <template #icon>
+          <n-icon size="20">
+            <dark-mode-outlined />
+          </n-icon>
+        </template>
+        Dark
+      </n-button>
+
+      <n-button
+        ghost
+        style="margin-left: 20px"
+        @click="disableDarkMode(false)"
+        type="default"
+        v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
+        v-else
+      >
+        <template #icon>
+          <n-icon size="20">
+            <light-mode-outlined />
+          </n-icon>
+        </template>
+        Light
+      </n-button>
+
+      <n-icon
+        size="30"
+        style="margin-left: 20px"
+        v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
+      >
+        <menu-sharp />
+      </n-icon>
+    </div>
   </n-layout-header>
 </template>
 
@@ -73,7 +93,7 @@ function disableDarkMode(isDark: boolean) {
   store.setDarkMode(isDark);
 }
 
-const menuOptions: MenuOption[] = [
+const appNavigation: MenuOption[] = [
   {
     label: () =>
       h(
@@ -122,11 +142,27 @@ defineComponent({
 </script>
 
 <style scoped>
-.logo-title {
+.side-container-left {
   min-width: 240px;
   display: flex;
   height: 100%;
   align-items: center;
+}
+
+.side-container-right {
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+
+.side-container-right {
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+
+.side-container-item {
+  padding: 0px 20px;
 }
 
 .logo {
@@ -137,7 +173,7 @@ defineComponent({
   margin: 0px;
 }
 
-.links {
+.menu {
   flex: auto;
 }
 

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -1,20 +1,59 @@
 <template>
   <n-layout-header bordered>
-    <router-link color="red" to="/">Home</router-link>
-    <router-link to="/play">Play</router-link>
+    <div class="logo-title">
+      <n-icon size="30" class="logo">
+        <diamond-sharp />
+      </n-icon>
+      <n-h3 class="title">Rup Games</n-h3>
+    </div>
+    <div class="links">
+      <router-link to="/">Home</router-link>
+      <router-link to="/about">About</router-link>
+      <router-link to="/play">Play</router-link>
+    </div>
+    <n-icon size="30">
+      <menu-sharp />
+    </n-icon>
   </n-layout-header>
 </template>
 
 <script setup lang="ts">
+import { defineComponent } from "vue";
 import { RouterLink } from "vue-router";
-import { NLayoutHeader } from "naive-ui";
+import { NLayoutHeader, NIcon, NH3 } from "naive-ui";
+import { DiamondSharp, MenuSharp } from "@vicons/material";
+
+defineComponent({
+  DiamondSharp,
+  MenuSharp,
+});
 </script>
 
 <style scoped>
+.logo-title {
+  min-width: 200px;
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+
+.logo {
+  margin-right: 6px;
+}
+
+.title {
+  margin: 0px;
+}
+
+.links {
+  flex: auto;
+}
+
 .n-layout-header {
-  height: 70px;
+  height: 64px;
   padding: 0px 24px 0px 24px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 </style>

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -6,10 +6,10 @@
       </n-icon>
       <n-h3 class="title">Rup Games</n-h3>
     </div>
-    <div class="links">
+    <div class="links" v-show="windowWidth > 600">
       <n-menu mode="horizontal" :options="menuOptions" />
     </div>
-    <n-icon size="30" v-if="windowWidth < 600">
+    <n-icon size="30" v-show="windowWidth <= 600">
       <menu-sharp />
     </n-icon>
   </n-layout-header>
@@ -70,7 +70,7 @@ defineComponent({
 
 <style scoped>
 .logo-title {
-  min-width: 200px;
+  min-width: 240px;
   display: flex;
   height: 100%;
   align-items: center;

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -6,10 +6,42 @@
       </n-icon>
       <n-h3 class="title">Rup Games</n-h3>
     </div>
-    <div class="links" v-show="windowWidth > 600">
+    <div
+      class="links"
+      v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
+    >
       <n-menu mode="horizontal" :options="menuOptions" />
     </div>
-    <n-icon size="30" v-show="windowWidth <= 600">
+    <n-button
+      ghost
+      type="primary"
+      v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
+      v-if="!store.darkMode"
+    >
+      <template #icon>
+        <n-icon size="20">
+          <light-mode-outlined />
+        </n-icon>
+      </template>
+      Light
+    </n-button>
+    <n-button
+      ghost
+      type="primary"
+      v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
+      v-else
+    >
+      <template #icon>
+        <n-icon size="20">
+          <dark-mode-outlined />
+        </n-icon>
+      </template>
+      Dark
+    </n-button>
+    <n-icon
+      size="30"
+      v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
+    >
       <menu-sharp />
     </n-icon>
   </n-layout-header>
@@ -18,13 +50,17 @@
 <script setup lang="ts">
 import { defineComponent, h } from "vue";
 import { RouterLink } from "vue-router";
-import { NLayoutHeader, NIcon, NH3, NMenu } from "naive-ui";
+import { NLayoutHeader, NIcon, NH3, NMenu, NButton } from "naive-ui";
 import type { MenuOption } from "naive-ui";
-import { DiamondSharp, MenuSharp } from "@vicons/material";
+import { useStore } from "../store/store";
+import {
+  DiamondSharp,
+  MenuSharp,
+  LightModeOutlined,
+  DarkModeOutlined,
+} from "@vicons/material";
 
-defineProps<{
-  windowWidth: Number;
-}>();
+const store = useStore();
 
 const menuOptions: MenuOption[] = [
   {
@@ -65,6 +101,8 @@ const menuOptions: MenuOption[] = [
 defineComponent({
   DiamondSharp,
   MenuSharp,
+  LightModeOutlined,
+  DarkModeOutlined,
 });
 </script>
 

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -1,10 +1,12 @@
 <template>
   <n-layout-header bordered>
     <div class="side-container-left">
-      <n-icon size="30" class="logo">
-        <diamond-sharp />
-      </n-icon>
-      <n-h3 class="title">Rup Games</n-h3>
+      <n-button text :focusable="false">
+        <n-icon size="30" class="logo">
+          <diamond-sharp />
+        </n-icon>
+        <n-h3 class="title">Rup Games</n-h3>
+      </n-button>
     </div>
 
     <div
@@ -25,13 +27,14 @@
         tag="a"
         href="https://github.com/waylonturbes/square-game"
         target="_blank"
+        :focusable="false"
         v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
       >
         GitHub
       </n-button>
 
       <n-button
-        ghost
+        text
         style="margin-left: 20px"
         @click="disableDarkMode(true)"
         type="default"
@@ -47,7 +50,7 @@
       </n-button>
 
       <n-button
-        ghost
+        text
         style="margin-left: 20px"
         @click="disableDarkMode(false)"
         type="default"
@@ -62,13 +65,14 @@
         Light
       </n-button>
 
-      <n-icon
-        size="30"
-        style="margin-left: 20px"
-        v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
-      >
-        <menu-sharp />
-      </n-icon>
+      <n-button text style="margin-left: 20px">
+        <n-icon
+          size="30"
+          v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
+        >
+          <menu-sharp />
+        </n-icon>
+      </n-button>
     </div>
   </n-layout-header>
 </template>
@@ -145,20 +149,13 @@ defineComponent({
 .side-container-left {
   min-width: 240px;
   display: flex;
-  height: 100%;
   align-items: center;
 }
 
 .side-container-right {
   display: flex;
-  height: 100%;
   align-items: center;
-}
-
-.side-container-right {
-  display: flex;
-  height: 100%;
-  align-items: center;
+  justify-content: flex-end;
 }
 
 .side-container-item {

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -14,6 +14,7 @@
     </div>
     <n-button
       ghost
+      @click="disableDarkMode(true)"
       type="primary"
       v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
       v-if="!store.darkMode"
@@ -27,6 +28,7 @@
     </n-button>
     <n-button
       ghost
+      @click="disableDarkMode(false)"
       type="primary"
       v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
       v-else
@@ -61,6 +63,10 @@ import {
 } from "@vicons/material";
 
 const store = useStore();
+
+function disableDarkMode(isDark: boolean) {
+  store.setDarkMode(isDark);
+}
 
 const menuOptions: MenuOption[] = [
   {

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -1,12 +1,14 @@
 <template>
   <n-layout-header bordered>
     <div class="side-container-left">
-      <n-button text :focusable="false">
-        <n-icon size="30" class="logo">
-          <diamond-sharp />
-        </n-icon>
-        <n-h3 class="title">Rup Games</n-h3>
-      </n-button>
+      <router-link to="/" style="text-decoration: none; height: 30px">
+        <n-button text :focusable="false">
+          <n-icon size="30" class="logo">
+            <diamond-sharp />
+          </n-icon>
+          <n-h3 class="title">Rup Games</n-h3>
+        </n-button>
+      </router-link>
     </div>
 
     <div
@@ -65,22 +67,72 @@
         Light
       </n-button>
 
-      <n-button text style="margin-left: 20px">
-        <n-icon
-          size="30"
-          v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
-        >
+      <n-button
+        text
+        :focusable="false"
+        @click="activateDrawer"
+        v-show="store.windowWidth === 'xs' || store.windowWidth === 'sm'"
+      >
+        <n-icon size="30">
           <menu-sharp />
         </n-icon>
       </n-button>
     </div>
+    <n-drawer v-model:show="showDrawer" :width="240" placement="right">
+      <n-drawer-content>
+        <n-menu
+          :value="`${currentRoute.name}`"
+          mode="vertical"
+          :options="appNavigation"
+        />
+        <div class="drawer-theme-btn-container">
+          <n-button
+            ghost
+            class="drawer-theme-btn"
+            @click="disableDarkMode(true)"
+            type="default"
+            v-if="!store.darkMode"
+          >
+            <template #icon>
+              <n-icon size="20">
+                <dark-mode-outlined />
+              </n-icon>
+            </template>
+            Dark
+          </n-button>
+
+          <n-button
+            ghost
+            class="drawer-theme-btn"
+            @click="disableDarkMode(false)"
+            type="default"
+            v-else
+          >
+            <template #icon>
+              <n-icon size="20">
+                <light-mode-outlined />
+              </n-icon>
+            </template>
+            Light
+          </n-button>
+        </div>
+      </n-drawer-content>
+    </n-drawer>
   </n-layout-header>
 </template>
 
 <script setup lang="ts">
-import { defineComponent, h } from "vue";
+import { defineComponent, h, ref } from "vue";
 import { RouterLink, useRoute } from "vue-router";
-import { NLayoutHeader, NIcon, NH3, NMenu, NButton } from "naive-ui";
+import {
+  NLayoutHeader,
+  NIcon,
+  NH3,
+  NMenu,
+  NButton,
+  NDrawer,
+  NDrawerContent,
+} from "naive-ui";
 import type { MenuOption } from "naive-ui";
 import { useStore } from "../store/store";
 import {
@@ -93,8 +145,14 @@ import {
 const store = useStore();
 const currentRoute = useRoute();
 
+const showDrawer = ref(false);
+
 function disableDarkMode(isDark: boolean) {
   store.setDarkMode(isDark);
+}
+
+function activateDrawer() {
+  showDrawer.value = !showDrawer.value;
 }
 
 const appNavigation: MenuOption[] = [
@@ -155,7 +213,6 @@ defineComponent({
 .side-container-right {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
 }
 
 .side-container-item {
@@ -180,5 +237,17 @@ defineComponent({
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.drawer-theme-btn-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.drawer-theme-btn {
+  width: 176px;
+  height: 42px;
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from "vue";
-
+import { createPinia } from "pinia";
 import App from "./App.vue";
 import router from "./navigation/router";
 
@@ -8,8 +8,10 @@ import "vfonts/Lato.css";
 // Monospace Font
 import "vfonts/FiraCode.css";
 
+const pinia = createPinia();
 const vueApp = createApp(App);
 
 vueApp.use(router);
+vueApp.use(pinia);
 
 vueApp.mount("#app");

--- a/src/navigation/router.ts
+++ b/src/navigation/router.ts
@@ -3,13 +3,13 @@ import { createRouter, createWebHistory } from "vue-router";
 import { HomeView, PlayView } from "../views";
 
 const routes = [
-    { path: "/", component: HomeView },
-    { path: "/play", component: PlayView },
+  { path: "/", name: "home", component: HomeView },
+  { path: "/play", name: "play", component: PlayView },
 ];
 
 const router = createRouter({
-    history: createWebHistory(),
-    routes,
+  history: createWebHistory(),
+  routes,
 });
 
 export default router;

--- a/src/navigation/router.ts
+++ b/src/navigation/router.ts
@@ -1,9 +1,10 @@
 import { createRouter, createWebHistory } from "vue-router";
 
-import { HomeView, PlayView } from "../views";
+import { HomeView, AboutView, PlayView } from "../views";
 
 const routes = [
   { path: "/", name: "home", component: HomeView },
+  { path: "/about", name: "about", component: AboutView },
   { path: "/play", name: "play", component: PlayView },
 ];
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,25 @@
+import { defineStore } from "pinia";
+
+export const useStore = defineStore("main", {
+  state: () => {
+    return { windowWidth: "", darkMode: false };
+  },
+  actions: {
+    setDarkMode(isDark: boolean) {
+      this.darkMode = isDark;
+    },
+    setWindowWidth() {
+      if (innerWidth <= 600) {
+        this.windowWidth = "xs";
+      } else if (innerWidth > 600 && innerWidth <= 960) {
+        this.windowWidth = "sm";
+      } else if (innerWidth > 960 && innerWidth <= 1264) {
+        this.windowWidth = "md";
+      } else if (innerWidth > 1264 && innerWidth <= 1904) {
+        this.windowWidth = "lg";
+      } else {
+        this.windowWidth = "xl";
+      }
+    },
+  },
+});

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,0 +1,5 @@
+<template>
+  <div></div>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -1,2 +1,3 @@
 export { default as HomeView } from "./HomeView.vue";
+export { default as AboutView } from "./AboutView.vue";
 export { default as PlayView } from "./PlayView.vue";


### PR DESCRIPTION
## Description

Building out the application's app header, so that a user can us it to navigate across site and toggle the site's theme.

- Created a menu list for displays over 600px that links to the sites different routes
- Created drawer with menu list of links to all of the site's routes
- New buttons that toggle dark mode

### Side changes/additions

- Installed `pinia` and initialized a store
- Removed font-awesome icons, added material icons
- Created a global width variable (for responsive design)