### PR TITLE
Feat: User Account Navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,21 @@ supabase.auth.onAuthStateChange(async (_, session: any) => {
   store.setUser({
     ...user,
     ...data,
+    isSignedIn: localStorage.getItem("supabase.auth.token") ? true : false,
   });
+  try {
+    const { data, error } = await supabase.storage
+      .from("avatars")
+      .download(store.user.avatar_url);
+    if (error) throw error;
+    const copyOfData: any = data;
+    store.setUser({
+      ...store.user,
+      avatar_url: URL.createObjectURL(copyOfData),
+    });
+  } catch (error: any) {
+    console.error("Error downloading image: ", error.message);
+  }
 });
 
 defineComponent({

--- a/src/components/ProfileAvatar.vue
+++ b/src/components/ProfileAvatar.vue
@@ -87,6 +87,7 @@ const downloadImage = async () => {
     if (error) throw error;
     const copyOfData: any = data;
     src.value = URL.createObjectURL(copyOfData);
+    store.setUser({ ...store.user, avatar_url: src.value });
   } catch (error: any) {
     console.error("Error downloading image: ", error.message);
   }

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -23,33 +23,43 @@
     </div>
 
     <div class="side-container-right">
-      <n-button
-        class="side-container-item"
-        text
-        tag="a"
-        href="https://github.com/waylonturbes/square-game"
-        target="_blank"
-        :focusable="false"
+      <div
+        class="side-container-right-desktop"
         v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
       >
-        GitHub
-      </n-button>
+        <n-button
+          class="side-container-item"
+          text
+          tag="a"
+          href="https://github.com/waylonturbes/square-game"
+          target="_blank"
+          :focusable="false"
+        >
+          GitHub
+        </n-button>
 
-      <n-button
-        text
-        style="margin-left: 20px"
-        @click="disableDarkMode(store.darkMode === true ? false : true)"
-        type="default"
-        v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
-      >
-        <template #icon>
-          <n-icon size="20">
-            <light-mode-outlined v-if="store.darkMode === false" />
-            <dark-mode-outlined v-else />
-          </n-icon>
-        </template>
-        {{ store.darkMode === true ? "Dark" : "Light" }}
-      </n-button>
+        <n-button
+          class="side-container-item"
+          text
+          style="margin-left: 0px"
+          @click="disableDarkMode(store.darkMode === true ? false : true)"
+          type="default"
+        >
+          <template #icon>
+            <n-icon size="20">
+              <light-mode-outlined v-if="store.darkMode === false" />
+              <dark-mode-outlined v-else />
+            </n-icon>
+          </template>
+          {{ store.darkMode === true ? "Dark" : "Light" }}
+        </n-button>
+
+        <div style="padding-left: 20px; display: flex; align-items: center">
+          <n-button style="padding: 0px; height: 40px">
+            <n-avatar size="large" :src="store.user.avatar_url"> </n-avatar>
+          </n-button>
+        </div>
+      </div>
 
       <n-button
         text
@@ -107,8 +117,9 @@
 </template>
 
 <script setup lang="ts">
-import { defineComponent, h, ref } from "vue";
+import { defineComponent, h, ref, watch, onMounted } from "vue";
 import { RouterLink, useRoute } from "vue-router";
+import { supabase } from "../supabase";
 import {
   NLayoutHeader,
   NIcon,
@@ -132,6 +143,20 @@ const store = useStore();
 const currentRoute = useRoute();
 
 const showDrawer = ref(false);
+const src = ref("");
+
+const downloadImage = async () => {
+  try {
+    const { data, error } = await supabase.storage
+      .from("avatars")
+      .download(store.user.avatar_url);
+    if (error) throw error;
+    const copyOfData: any = data;
+    src.value = URL.createObjectURL(copyOfData);
+  } catch (error: any) {
+    console.error("Error downloading image: ", error.message);
+  }
+};
 
 function disableDarkMode(isDark: boolean) {
   store.setDarkMode(isDark);
@@ -181,6 +206,12 @@ const appNavigation: MenuOption[] = [
   },
 ];
 
+// const copyAvatarURL: any = store.user.avatar_url;
+
+onMounted(() => {
+  downloadImage();
+});
+
 defineComponent({
   DiamondSharp,
   MenuSharp,
@@ -195,28 +226,22 @@ defineComponent({
   display: flex;
   align-items: center;
 }
-
 .side-container-right {
   display: flex;
   align-items: center;
 }
-
 .side-container-item {
   padding: 0px 20px;
 }
-
 .logo {
   margin-right: 6px;
 }
-
 .title {
   margin: 0px;
 }
-
 .menu {
   flex: auto;
 }
-
 .n-layout-header {
   height: 64px;
   padding: 0px 24px 0px 24px;
@@ -225,14 +250,16 @@ defineComponent({
   justify-content: space-between;
   position: fixed;
 }
-
+.side-container-right-desktop {
+  display: flex;
+  align-items: center;
+}
 .drawer-theme-btn-container {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
 }
-
 .drawer-theme-btn {
   width: 176px;
   height: 42px;

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -91,35 +91,20 @@
           mode="vertical"
           :options="appNavigation"
         />
-        <div class="drawer-theme-btn-container">
+        <div class="drawer-custom-btn-container">
           <n-button
             ghost
-            class="drawer-theme-btn"
-            @click="disableDarkMode(true)"
+            class="drawer-custom-btn"
+            @click="disableDarkMode(store.darkMode === true ? false : true)"
             type="default"
-            v-if="!store.darkMode"
           >
             <template #icon>
               <n-icon size="20">
-                <dark-mode-outlined />
+                <light-mode-outlined v-if="store.darkMode === false" />
+                <dark-mode-outlined v-else />
               </n-icon>
             </template>
-            Dark
-          </n-button>
-
-          <n-button
-            ghost
-            class="drawer-theme-btn"
-            @click="disableDarkMode(false)"
-            type="default"
-            v-else
-          >
-            <template #icon>
-              <n-icon size="20">
-                <light-mode-outlined />
-              </n-icon>
-            </template>
-            Light
+            {{ store.darkMode === true ? "Dark" : "Light" }}
           </n-button>
         </div>
       </n-drawer-content>
@@ -279,13 +264,13 @@ defineComponent({
   display: flex;
   align-items: center;
 }
-.drawer-theme-btn-container {
+.drawer-custom-btn-container {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
 }
-.drawer-theme-btn {
+.drawer-custom-btn {
   width: 176px;
   height: 42px;
 }

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -160,19 +160,6 @@ const message = useMessage();
 const showDrawer = ref(false);
 const src = ref("");
 
-const downloadImage = async () => {
-  try {
-    const { data, error } = await supabase.storage
-      .from("avatars")
-      .download(store.user.avatar_url);
-    if (error) throw error;
-    const copyOfData: any = data;
-    src.value = URL.createObjectURL(copyOfData);
-  } catch (error: any) {
-    console.error("Error downloading image: ", error.message);
-  }
-};
-
 const disableDarkMode = (isDark: boolean) => {
   store.setDarkMode(isDark);
 };
@@ -249,14 +236,6 @@ const profileOptions = [
     key: "sign-out",
   },
 ];
-
-// const copyAvatarURL: any = store.user.avatar_url;
-
-onMounted(() => {
-  if (store.user.isSignedIn) {
-    downloadImage();
-  }
-});
 
 defineComponent({
   DiamondSharp,

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -55,9 +55,15 @@
         </n-button>
 
         <div style="padding-left: 20px; display: flex; align-items: center">
-          <n-button style="padding: 0px; height: 40px">
-            <n-avatar size="large" :src="store.user.avatar_url"> </n-avatar>
-          </n-button>
+          <n-dropdown
+            trigger="click"
+            :options="profileOptions"
+            @select="handleSelect"
+          >
+            <n-button style="padding: 0px; height: 40px">
+              <n-avatar size="large" :src="store.user.avatar_url"> </n-avatar>
+            </n-button>
+          </n-dropdown>
         </div>
       </div>
 
@@ -117,8 +123,8 @@
 </template>
 
 <script setup lang="ts">
-import { defineComponent, h, ref, watch, onMounted } from "vue";
-import { RouterLink, useRoute } from "vue-router";
+import { defineComponent, h, ref, onMounted } from "vue";
+import { RouterLink, useRoute, useRouter } from "vue-router";
 import { supabase } from "../supabase";
 import {
   NLayoutHeader,
@@ -129,6 +135,8 @@ import {
   NDrawer,
   NDrawerContent,
   NAvatar,
+  useMessage,
+  NDropdown,
 } from "naive-ui";
 import type { MenuOption } from "naive-ui";
 import { useStore } from "../store/store";
@@ -141,9 +149,12 @@ import {
 
 const store = useStore();
 const currentRoute = useRoute();
+const router = useRouter();
+const message = useMessage();
 
 const showDrawer = ref(false);
 const src = ref("");
+const showDropdown = ref(false);
 
 const downloadImage = async () => {
   try {
@@ -164,6 +175,20 @@ function disableDarkMode(isDark: boolean) {
 
 function activateDrawer() {
   showDrawer.value = !showDrawer.value;
+}
+
+async function handleSelect(key: string | number) {
+  if (String(key) === "profile") {
+    router.push("/profile");
+  } else {
+    let { error } = await supabase.auth.signOut();
+    if (error) {
+      message.error(
+        "Failed to sign out! If issue persists, delete your token in localStorage"
+      );
+    }
+    router.push("/");
+  }
 }
 
 const appNavigation: MenuOption[] = [
@@ -203,6 +228,17 @@ const appNavigation: MenuOption[] = [
         { default: () => "Play" }
       ),
     key: "play",
+  },
+];
+
+const profileOptions = [
+  {
+    label: "Profile",
+    key: "profile",
+  },
+  {
+    label: "Sign Out",
+    key: "sign-out",
   },
 ];
 

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -56,14 +56,19 @@
 
         <div style="padding-left: 20px; display: flex; align-items: center">
           <n-dropdown
+            v-if="store.user.isSignedIn"
             trigger="click"
             :options="profileOptions"
-            @select="handleSelect"
+            @select="handleProfileSelect"
           >
             <n-button style="padding: 0px; height: 40px">
               <n-avatar size="large" :src="store.user.avatar_url"> </n-avatar>
             </n-button>
           </n-dropdown>
+
+          <n-button v-else :focusable="false" @click.prevent="goToSignIn">
+            Sign In
+          </n-button>
         </div>
       </div>
 
@@ -154,7 +159,6 @@ const message = useMessage();
 
 const showDrawer = ref(false);
 const src = ref("");
-const showDropdown = ref(false);
 
 const downloadImage = async () => {
   try {
@@ -169,15 +173,15 @@ const downloadImage = async () => {
   }
 };
 
-function disableDarkMode(isDark: boolean) {
+const disableDarkMode = (isDark: boolean) => {
   store.setDarkMode(isDark);
-}
+};
 
-function activateDrawer() {
+const activateDrawer = () => {
   showDrawer.value = !showDrawer.value;
-}
+};
 
-async function handleSelect(key: string | number) {
+const handleProfileSelect = async (key: string | number) => {
   if (String(key) === "profile") {
     router.push("/profile");
   } else {
@@ -189,7 +193,11 @@ async function handleSelect(key: string | number) {
     }
     router.push("/");
   }
-}
+};
+
+const goToSignIn = () => {
+  router.push("/signin");
+};
 
 const appNavigation: MenuOption[] = [
   {
@@ -245,7 +253,9 @@ const profileOptions = [
 // const copyAvatarURL: any = store.user.avatar_url;
 
 onMounted(() => {
-  downloadImage();
+  if (store.user.isSignedIn) {
+    downloadImage();
+  }
 });
 
 defineComponent({

--- a/src/components/RupHeader.vue
+++ b/src/components/RupHeader.vue
@@ -38,33 +38,17 @@
       <n-button
         text
         style="margin-left: 20px"
-        @click="disableDarkMode(true)"
+        @click="disableDarkMode(store.darkMode === true ? false : true)"
         type="default"
         v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
-        v-if="!store.darkMode"
       >
         <template #icon>
           <n-icon size="20">
-            <dark-mode-outlined />
+            <light-mode-outlined v-if="store.darkMode === false" />
+            <dark-mode-outlined v-else />
           </n-icon>
         </template>
-        Dark
-      </n-button>
-
-      <n-button
-        text
-        style="margin-left: 20px"
-        @click="disableDarkMode(false)"
-        type="default"
-        v-show="store.windowWidth !== 'xs' && store.windowWidth !== 'sm'"
-        v-else
-      >
-        <template #icon>
-          <n-icon size="20">
-            <light-mode-outlined />
-          </n-icon>
-        </template>
-        Light
+        {{ store.darkMode === true ? "Dark" : "Light" }}
       </n-button>
 
       <n-button
@@ -78,6 +62,7 @@
         </n-icon>
       </n-button>
     </div>
+
     <n-drawer v-model:show="showDrawer" :width="240" placement="right">
       <n-drawer-content>
         <n-menu
@@ -132,6 +117,7 @@ import {
   NButton,
   NDrawer,
   NDrawerContent,
+  NAvatar,
 } from "naive-ui";
 import type { MenuOption } from "naive-ui";
 import { useStore } from "../store/store";

--- a/src/components/RupSignInForm.vue
+++ b/src/components/RupSignInForm.vue
@@ -9,7 +9,7 @@
       size="large"
       class="sign-in-form"
     >
-      <n-form-item label="Email" path="email">
+      <n-form-item label="Email" path="email" style="margin: 0px; width: 280px">
         <n-input
           v-model:value="formValues.email"
           placeholder="Input your email"

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 
 interface UserDataValues {
+  isSignedIn: boolean;
   id: string;
   email: string;
   username?: string;
@@ -15,6 +16,7 @@ export const useStore = defineStore("main", {
       windowWidth: "",
       darkMode: false,
       user: {
+        isSignedIn: false,
         id: "",
         email: "",
         username: "",
@@ -43,6 +45,7 @@ export const useStore = defineStore("main", {
     },
     setUser(userData: UserDataValues) {
       const newData: UserDataValues = {
+        isSignedIn: userData.isSignedIn || false,
         id: userData.id,
         email: userData.email,
         username: userData.username,

--- a/src/views/UserProfileView.vue
+++ b/src/views/UserProfileView.vue
@@ -77,7 +77,7 @@ async function getProfile() {
   try {
     loading.value = true;
     const user: any = supabase.auth.user();
-    store.setUser(user);
+    store.setUser({ ...store.user, ...user });
 
     let { data, error, status } = await supabase
       .from("profiles")


### PR DESCRIPTION
## Description

Adding links to the profile and sign-in views, that way users can access them.

- Added an avatar button to the header, which links to `/profile` and has a sign out button

[TODO] - Add sign out and profile navigation links to `RupHeader`'s hamburger menu



### Side changes/additions

- Increased width of the sign-in form